### PR TITLE
Fixed build of the null_backend - and examples - on MSVC 2017

### DIFF
--- a/examples/melody.cpp
+++ b/examples/melody.cpp
@@ -3,10 +3,15 @@
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
+#ifdef WIN32
+#define _USE_MATH_DEFINES
+#endif
 #include <cmath>
 #include <array>
 #include <thread>
 #include <audio>
+#include <cassert>
+#include <atomic>
 
 // This example app plays a short melody using a simple square wave synthesiser.
 

--- a/examples/sine_wave.cpp
+++ b/examples/sine_wave.cpp
@@ -3,6 +3,9 @@
 // Distributed under the Boost Software License, Version 1.0.
 // (See accompanying file LICENSE.md or copy at http://boost.org/LICENSE_1_0.txt)
 
+#ifdef WIN32
+#define _USE_MATH_DEFINES
+#endif
 #include <cmath>
 #include <thread>
 #include <audio>

--- a/include/__audio_strided_span
+++ b/include/__audio_strided_span
@@ -6,6 +6,7 @@
 #pragma once
 #include <vector>
 #include <iterator>
+#include <cassert>
 #include <__audio_config>
 
 _LIBSTDAUDIO_NAMESPACE_BEGIN

--- a/src/backend/null_backend.cpp
+++ b/src/backend/null_backend.cpp
@@ -18,6 +18,16 @@ device get_output_device() {
   return {};
 }
 
+device get_default_input_device()
+{
+	return {};
+}
+
+device get_default_output_device()
+{
+	return {};
+}
+
 device_list& get_input_device_list() {
   static device_list in_devices{device_list::_underlying_container{}};
   return in_devices;
@@ -27,14 +37,14 @@ device_list& get_output_device_list() {
   static device_list out_devices{device_list::_underlying_container{}};
   return out_devices;
 }
-
-int buffer_list::num_input_buffers() const noexcept {
-  return 0;
-}
-
-int buffer_list::num_output_buffers() const noexcept {
-  return 0;
-}
+//TODO is this thing necessary?
+//int buffer_list::num_input_buffers() const noexcept {
+//  return 0;
+//}
+//
+//int buffer_list::num_output_buffers() const noexcept {
+//  return 0;
+//}
 
 _LIBSTDAUDIO_NAMESPACE_END
 #endif // LIBSTDAUDIO_BACKEND_NONE

--- a/src/buffer.cpp
+++ b/src/buffer.cpp
@@ -6,6 +6,7 @@
 #include <__audio_buffer>
 #include <__audio_buffer_view>
 #include <vector>
+#include <cassert>
 
 _LIBSTDAUDIO_NAMESPACE_BEGIN
 


### PR DESCRIPTION
Hi,

I'm really interested into the project of adding a standard audio library to the C++ standard library. I would be interested into helping out implementing a `WASAPI` backed for this "sample" implementation of the paper. 

This little set of changes makes it possible to at least build the source code of the `null` backend and the examples.

I am aware that a revision of the paper (R1) dated from march 11 changes things this PR touches, notably the `buffer_list` class seems to be going away, but I think it's at least nice to have the examples being somewhat buildable. 

Theses changes are pretty minor (missing includes for using `assert` and `std::atomic`. Missing define on Windows to get Math constant when including `cmath`)

I'm going to try to replicate what was done in the `coreaudio` backed, but for MS Windows. 😄 